### PR TITLE
Add Flathub plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -108,7 +108,7 @@
 
 			"version": "1.0.0",
 			"archive": "https://github.com/ShadowBlip/crankshaft-flathub/releases/download/v1.0.0/crankshaft-flathub-v1.0.0.tar.gz",
-			"sha256": "b49ada79ca7ca381968eb0f6dbdf7f0fda3182536f8bdca9693b0225f0aefa56",
+			"sha256": "73f3ccdb4e40929c56fe09a59d5ebbc98f6118fe55fe40ae48cbe15f43534188",
 			
 			"name": "Flathub",
 			"author": "William Edwards",

--- a/plugins.json
+++ b/plugins.json
@@ -101,6 +101,19 @@
 			"author": "SDHQ",
 			"minCrankshaftVersion": "0.2.1",
 			"source": "https://github.com/shelbykleindesign/steamdeckhq-crankshaft-plugin"
+		},
+		{
+			"id": "crankshaft-flathub",
+			"repo": "https://github.com/ShadowBlip/crankshaft-flathub",
+
+			"version": "1.0.0",
+			"archive": "https://github.com/ShadowBlip/crankshaft-flathub/releases/download/v1.0.0/crankshaft-flathub-v1.0.0.tar.gz",
+			"sha256": "b49ada79ca7ca381968eb0f6dbdf7f0fda3182536f8bdca9693b0225f0aefa56",
+			
+			"name": "Flathub",
+			"author": "William Edwards",
+			"minCrankshaftVersion": "0.1.5",
+			"source": "https://github.com/ShadowBlip/crankshaft-flathub"
 		}
 	]
 }


### PR DESCRIPTION
This PR adds the FlatHub plugin to the Crankshaft plugin store. It allows you to browse, search, install, and uninstall Flatpaks from Flathub and also creates Steam shortcuts using the [steam-shortcut-manager](https://github.com/ShadowBlip/steam-shortcut-manager) tool (written in Go). Using the shortcut manager it will also try and download the grid artwork for a given Flatpak automatically so Flatpaks look nice in your library.

![](https://github.com/ShadowBlip/crankshaft-flathub/raw/main/doc/image01.png)

![](https://github.com/ShadowBlip/crankshaft-flathub/raw/main/doc/image02.png)

**NOTE:** This current release only allows you to search using a keyboard. I'm hoping to add on-screen keyboard support in future releases.