### PR TITLE
Update Flathub plugin to v1.1.1

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -106,9 +106,9 @@
 			"id": "crankshaft-flathub",
 			"repo": "https://github.com/ShadowBlip/crankshaft-flathub",
 
-			"version": "1.1.0",
-			"archive": "https://github.com/ShadowBlip/crankshaft-flathub/releases/download/v1.1.0/crankshaft-flathub-v1.1.0.tar.gz",
-			"sha256": "a62fee09cc1b67c811d3f8d0011649392e4d3624e46a8c891c78df279998a049",
+			"version": "1.1.1",
+			"archive": "https://github.com/ShadowBlip/crankshaft-flathub/releases/download/v1.1.1/crankshaft-flathub-v1.1.1.tar.gz",
+			"sha256": "f385ec0292380f80b99a582cccf0b156d8497cb2175b5acd9149b0df8fa45e1f",
 			"name": "Flathub",
 			"author": "William Edwards",
 			"minCrankshaftVersion": "0.2.1",


### PR DESCRIPTION
This is a quick fix for some users who try to install a package that is in multiple flatpak repos. This change now specifies to install from the Flatpak stable repository.