### PR TITLE
Update Flathub to v1.1.2

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -106,9 +106,9 @@
 			"id": "crankshaft-flathub",
 			"repo": "https://github.com/ShadowBlip/crankshaft-flathub",
 
-			"version": "1.1.1",
-			"archive": "https://github.com/ShadowBlip/crankshaft-flathub/releases/download/v1.1.1/crankshaft-flathub-v1.1.1.tar.gz",
-			"sha256": "f385ec0292380f80b99a582cccf0b156d8497cb2175b5acd9149b0df8fa45e1f",
+			"version": "1.1.2",
+			"archive": "https://github.com/ShadowBlip/crankshaft-flathub/releases/download/v1.1.2/crankshaft-flathub-v1.1.2.tar.gz",
+			"sha256": "71974d06d6059e5a2ef8a978056170c6dca6068821b344b67b3fdc7dbc70218a",
 			"name": "Flathub",
 			"author": "William Edwards",
 			"minCrankshaftVersion": "0.2.1",


### PR DESCRIPTION
This release has another small bugfix for those using the plugin on [ChimeraOS](https://chimeraos.org/). Steam shortcuts would fail to create if no other shortcuts existed.

This is the exact change to the shortcut manager for this fix:
https://github.com/ShadowBlip/steam-shortcut-manager/commit/c9faba759ac273050cbeef231e3bc96794db7e68