### PR TITLE
Release flathub v1.1.3

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -106,12 +106,12 @@
 			"id": "crankshaft-flathub",
 			"repo": "https://github.com/ShadowBlip/crankshaft-flathub",
 
-			"version": "1.1.2",
-			"archive": "https://github.com/ShadowBlip/crankshaft-flathub/releases/download/v1.1.2/crankshaft-flathub-v1.1.2.tar.gz",
-			"sha256": "71974d06d6059e5a2ef8a978056170c6dca6068821b344b67b3fdc7dbc70218a",
+			"version": "1.1.3",
+			"archive": "https://github.com/ShadowBlip/crankshaft-flathub/releases/download/v1.1.3/crankshaft-flathub-v1.1.3.tar.gz",
+			"sha256": "7a7713348c802e7be553aebbd59bc2cfed6fd309e9f3f4f1902d3f3ec4d2d3f5",
 			"name": "Flathub",
 			"author": "William Edwards",
-			"minCrankshaftVersion": "0.2.1",
+			"minCrankshaftVersion": "0.2.2",
 			"source": "https://github.com/ShadowBlip/crankshaft-flathub"
 		}
 	]


### PR DESCRIPTION
Removed some of the hacks needed before Crankshaft v0.2.2. Also fixed a bug with image downloading from SteamGridDB's CDN.

Changelog:
https://github.com/ShadowBlip/crankshaft-flathub/compare/v1.1.2...v1.1.3