### PR TITLE
Add vibrantCrankshaft plugin

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -151,7 +151,7 @@
 			"source": "https://github.com/ZeroPoke/crankshaft-roundeck"
 		},
 		{
-			"id": "vibrant-crankshaft",
+			"id": "vibrantCrankshaft",
 			"repo": "https://github.com/ShadowBlip/vibrantCrankshaft",
 
 			"version": "1.0.0",

--- a/plugins.json
+++ b/plugins.json
@@ -154,9 +154,9 @@
 			"id": "vibrantCrankshaft",
 			"repo": "https://github.com/ShadowBlip/vibrantCrankshaft",
 
-			"version": "1.0.0",
-			"archive": "https://github.com/ShadowBlip/vibrantCrankshaft/releases/download/v1.0.0/vibrantCrankshaft-v1.0.0.tar.gz",
-			"sha256": "c7ab167136c1295c652fb2a4cd490fd0be6f47c0010f74c11563b745bdf1a093",
+			"version": "1.0.1",
+			"archive": "https://github.com/ShadowBlip/vibrantCrankshaft/releases/download/v1.0.1/vibrantCrankshaft-v1.0.1.tar.gz",
+			"sha256": "b7cc697e7afbb2741d4580541b370b5a9cb205b95ffd2b51029f3dc3b84ad4f8",
 			"name": "vibrantCrankshaft",
 			"author": "William Edwards",
 			"minCrankshaftVersion": "0.2.4",

--- a/plugins.json
+++ b/plugins.json
@@ -149,6 +149,18 @@
 			"author": "ZeroPoke",
 			"minCrankshaftVersion": "0.2.2",
 			"source": "https://github.com/ZeroPoke/crankshaft-roundeck"
+		},
+		{
+			"id": "vibrant-crankshaft",
+			"repo": "https://github.com/ShadowBlip/vibrantCrankshaft",
+
+			"version": "1.0.0",
+			"archive": "https://github.com/ShadowBlip/vibrantCrankshaft/releases/download/v1.0.0/vibrantCrankshaft-v1.0.0.tar.gz",
+			"sha256": "c7ab167136c1295c652fb2a4cd490fd0be6f47c0010f74c11563b745bdf1a093",
+			"name": "vibrantCrankshaft",
+			"author": "William Edwards",
+			"minCrankshaftVersion": "0.2.4",
+			"source": "https://github.com/ShadowBlip/vibrantCrankshaft"
 		}
 	]
 }


### PR DESCRIPTION
This plugin is a port of [vibrantDeck](https://github.com/libvibrant/vibrantDeck) to Crankshaft. It allows the user to adjust gamescope saturation globally and at a per-app level.

The repository can be found here:
https://github.com/ShadowBlip/vibrantCrankshaft

I wrote [deckyshaft.py](https://github.com/ShadowBlip/vibrantCrankshaft/blob/main/bin/deckyshaft.py) to load Decky backend plugins so they could be used as-is. There is a corresponding [deckyshaft.ts](https://github.com/ShadowBlip/vibrantCrankshaft/blob/main/src/deckyshaft/deckyshaft.ts) that (mostly) implements the Decky ServerAPI interface to allow calling to the backend plugin.