### PR TITLE
[MERGED] Add GitHub Action to validate plugins for GitHub PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  push:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.19
+
+    - name: Validate Plugins
+      run: make run
+


### PR DESCRIPTION
This PR adds a GitHub action that will run `make run` to validate plugins for pull requests from GitHub. If you had other CI options in mind on SourceHut, you can disregard/reject this PR if you didn't want it.